### PR TITLE
Fix canonical name of MapType

### DIFF
--- a/src/main/kotlin/net/fallingangel/jimmerdto/lsi/LType.kt
+++ b/src/main/kotlin/net/fallingangel/jimmerdto/lsi/LType.kt
@@ -105,6 +105,6 @@ sealed class LType {
             get() = "Map<${keyType.name}, ${valueType.name}>"
 
         override val canonicalName: String
-            get() = "Map<${keyType.canonicalName}>, ${valueType.canonicalName}>"
+            get() = "Map<${keyType.canonicalName}, ${valueType.canonicalName}>"
     }
 }


### PR DESCRIPTION
## Summary
- correct the template for `MapType.canonicalName`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fbc8ed45c8331ab24b82f602a2f47